### PR TITLE
Attest build provenance in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
+
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -36,11 +38,17 @@ jobs:
       - name: Pack
         run: python build.py pack
 
+      - name: Generate attestation for artifact
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: builds/${{ matrix.target }}.zip
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
+
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -48,7 +56,7 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   build_plugin:
     runs-on: windows-latest
     strategy:
@@ -63,11 +71,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
-      
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v3.3.0
         with:
@@ -77,16 +86,24 @@ jobs:
           arch:         ${{ matrix.qtarch }}
           dir:          ${{ runner.temp }}
           setup-python: true
+
       - name: Run build script
         run: python build.py ${{ matrix.cmd }}
 
       - name: Pack
         run: python build.py pack
+
+      - name: Generate attestation for artifact
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: builds/${{ matrix.target }}.zip
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
+
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -94,6 +111,7 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_everylang:
     runs-on: windows-latest
     strategy:
@@ -105,26 +123,35 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
+
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           architecture: x64
+
       - name: Run build script
         run: python build.py ${{ matrix.target }}
 
       - name: Pack
         run: python build.py pack
 
+      - name: Generate attestation for artifact
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: builds/${{ matrix.target }}.zip
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
+
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -132,4 +159,4 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
           - target: Release_English_winxp
           - target: Release_Chinese_winxp
           - target: Release_Russian_winxp
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,6 +72,10 @@ jobs:
           - cmd: plg64
             qtarch: win64_msvc2019_64
             target: plugin64
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -120,6 +128,10 @@ jobs:
           - target: Release_English
           - target: Release_Chinese
           - target: Release_Russian
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,15 @@ jobs:
           - target: Release_Chinese_winxp
           - target: Release_Russian_winxp
     permissions:
-      contents: write
       id-token: write
       attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
-
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -46,13 +43,11 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: builds/${{ matrix.target }}.zip
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
-
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -60,7 +55,7 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  
   build_plugin:
     runs-on: windows-latest
     strategy:
@@ -73,18 +68,16 @@ jobs:
             qtarch: win64_msvc2019_64
             target: plugin64
     permissions:
-      contents: write
       id-token: write
       attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
-
+      
       - name: Install Qt
         uses: jurplel/install-qt-action@v3.3.0
         with:
@@ -94,7 +87,6 @@ jobs:
           arch:         ${{ matrix.qtarch }}
           dir:          ${{ runner.temp }}
           setup-python: true
-
       - name: Run build script
         run: python build.py ${{ matrix.cmd }}
 
@@ -105,13 +97,11 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: builds/${{ matrix.target }}.zip
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
-
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -119,7 +109,6 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build_everylang:
     runs-on: windows-latest
     strategy:
@@ -129,24 +118,20 @@ jobs:
           - target: Release_Chinese
           - target: Release_Russian
     permissions:
-      contents: write
       id-token: write
       attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Setup Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
         with:
           sdk-version: 22621
-
       - name: Install Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           architecture: x64
-
       - name: Run build script
         run: python build.py ${{ matrix.target }}
 
@@ -157,13 +142,11 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: builds/${{ matrix.target }}.zip
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: builds/${{ matrix.target }}.zip
-
       - name: Release LunaHook
         uses: softprops/action-gh-release@v2
         with:
@@ -171,4 +154,4 @@ jobs:
           files: builds/${{ matrix.target }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  


### PR DESCRIPTION
Adds a way for users to verify provenance for the release binaries using [GitHub's new artifact attestations feature](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
With this an artifact could be verified by a user using a command like `gh attestation verify Release_English.zip -R HIllya51/LunaHook`.